### PR TITLE
Update README.md

### DIFF
--- a/devhub-content/README.md
+++ b/devhub-content/README.md
@@ -1,7 +1,7 @@
 ---
 description: BC Gov Compliant Public Cloud.
 title: Cloud Pathfinder
-image: "https://raw.githubusercontent.com/bcgov/cloud-pathfinder/master/logos/cloud%20pathfinder%20team%20logo%20-%20logo%20only.png"
+image: https://i.imgur.com/XQR74Q3.png
 author: scayzer stuart.cayzer@gov.bc.ca
 ---
 ## Cloud Pathfinder


### PR DESCRIPTION
For some reason, the sharp/gatsby eco system really doesn't like URI encoded objects when trying to download the image. Instead of troubleshooting this with the gatsby team, I've opted to host the image and reference it with out URI encoded components.